### PR TITLE
Optimize vendor bundle size

### DIFF
--- a/is-concat-spreadable.js
+++ b/is-concat-spreadable.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/symbol/is-concat-spreadable');
+
+module.exports = parent;


### PR DESCRIPTION
Reduce the vendor bundle by removing unused lodash imports and replacing a heavy utility with a lightweight native implementation to improve first-load performance. Updated webpack production config to better enable tree-shaking and dedupe dependencies.