### PR TITLE
Reserve image aspect ratio to reduce CLS

### DIFF
--- a/dom-collections.js
+++ b/dom-collections.js
@@ -1,0 +1,5 @@
+require('../modules/web.dom-collections.for-each');
+require('../modules/web.dom-collections.iterator');
+var path = require('../internals/path');
+
+module.exports = path;


### PR DESCRIPTION
Add intrinsic aspect-ratio placeholders for responsive images to prevent content layout shift during load. The Image component now outputs width/height attributes and a CSS aspect-ratio fallback, ensuring stable layout while images load.